### PR TITLE
Update irclock.asm to work with rom version r41

### DIFF
--- a/irclock.asm
+++ b/irclock.asm
@@ -6,13 +6,18 @@
 !byte $0A,$00			; 2-byte line number ($000A = 10)
 !byte $9E			; SYS BASIC token
 !byte $20			; [space]
-!byte $32,$30,$36,$34		; $32="2",$30="0",$36="6",$34="4"
+!byte $32,$30,$37,$30		; $32="2",$30="0",$37="7",$30="0"
 				; (ASCII encoded nums for dec starting addr)
 !byte $00			; End of Line
-!byte $00,$00			; This is address $080C containing
-				; 2-byte pointer to next line of BASIC code
-				; ($0000 = end of program)
-*=$0810				; The actual program starts here
+!byte $12, $08 ; This is address $080C containing
+	; 2-byte pointer to next line of BASIC code
+!byte $14, $00 ; Line 20
+!byte $A2 ; NEW BASIC token
+!byte $00 ; [ end of line ]
+!byte $00,$00 ; ($0000 = end of program)
+!byte $00,$00	
+				
+*=$0816				; The actual program starts here
 
 
 Old_irq_handler	= $0404		; 2 bytes to hold old IRQ handler address

--- a/irclock.asm
+++ b/irclock.asm
@@ -117,10 +117,11 @@ Show_clock:
 
 	; Set start address of clock and ensure VERA increments correctly
 	; This is top right corner in 80x60 mode
-	stz	VERA_ADDR_M
+	lda 	#$B0
+	sta	VERA_ADDR_M
 	lda	#144
 	sta	VERA_ADDR_L
-	lda	#$20
+	lda	#$21
 	sta	VERA_ADDR_H
 
 	; Write hours


### PR DESCRIPTION
In irclock.asm:
- update code that sets VERA_ADDR to work with r41